### PR TITLE
Release Type Support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Type of release'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   bump-tag-release:
@@ -30,10 +40,21 @@ jobs:
         run: |
           latest="${{ steps.get_tag.outputs.latest_tag }}"
           IFS='.' read -r -a parts <<< "${latest#v}"
-          major="${parts[0]}"
-          minor="${parts[1]}"
-          patch="${parts[2]}"
-          patch=$((patch + 1))
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event.inputs.release-type }}" == "patch" ]]; then
+            major="${parts[0]}"
+            minor="${parts[1]}"
+            patch="${parts[2]}"
+            patch=$((patch + 1))
+          elif [[ "${{ github.event.inputs.release-type }}" == "minor" ]]; then
+            major="${parts[0]}"
+            minor="${parts[1]}"
+            minor=$((minor + 1))
+            patch=0
+          elif [[ "${{ github.event.inputs.release-type }}" == "major" ]]; then
+            major=$((parts[0] + 1))
+            minor=0
+            patch=0
+          fi
           new_tag="v$major.$minor.$patch"
           echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow to allow selection of release type (patch, minor, major) when triggering a manual release. The version number will now increment based on the chosen release type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->