### PR TITLE
v0.3.4 Pause screen + bug fixes

### DIFF
--- a/include/Game.h
+++ b/include/Game.h
@@ -27,6 +27,7 @@ public:
 private:
     bool isRunning;
     bool quitPressed = false;
+    bool isPaused = false;
     std::atomic<int> lastInput{-1};
     std::vector<std::vector<int>> board;
     std::vector<Tetromino> bag;
@@ -55,6 +56,7 @@ private:
         {"score", 0}
     };
     double gameTime;
+    double totalPausedDuration;
 
     int fallDelay; // ms
     std::chrono::steady_clock::time_point lastFallTime;

--- a/include/UI.h
+++ b/include/UI.h
@@ -15,4 +15,5 @@ public:
     static void renderStatsWindow(WINDOW* win, const std::unordered_map<std::string, int>& statistics, double gameTime = 0.0);
     static void renderHandling(WINDOW* win);
     static void showResultsPage(const std::string& mode, const std::unordered_map<std::string, int>& statistics, double gameTime = 0.0);
+    static void showPauseScreen();
 };

--- a/include/UI.h
+++ b/include/UI.h
@@ -14,6 +14,7 @@ public:
     static void renderPieceBox(WINDOW* win, const Tetromino& tetromino, int cell_width = 2);
     static void renderStatsWindow(WINDOW* win, const std::unordered_map<std::string, int>& statistics, double gameTime = 0.0);
     static void renderHandling(WINDOW* win);
+    static std::string formatSeconds(double seconds);
     static void showResultsPage(const std::string& mode, const std::unordered_map<std::string, int>& statistics, double gameTime = 0.0);
     static void showPauseScreen();
 };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -254,7 +254,7 @@ void Game::handleInput(const Settings& settings, int ch) {
                     if (holdAvailable) {
                         currentPiece.setRotationState(0);
                         currentPiece.setX(3);
-                        currentPiece.setY(0);
+                        currentPiece.setY(20);
                         if (holdPiece.getType() != 0) {
                             std::swap(currentPiece, holdPiece);
                         } else {

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -49,6 +49,7 @@ void Game::reset() {
     };
     lastFallTime = std::chrono::steady_clock::now();
     gameStart = std::chrono::steady_clock::now();
+    totalPausedDuration = 0.0;
 }
 
 void Game::newPiece() {
@@ -100,6 +101,27 @@ void Game::run(const Settings& settings) {
     bool leftDCD = false, rightDCD = false;
     std::unordered_set<int> heldKeys;
     while (isRunning) {
+        if (isPaused) {
+            auto pauseStartTime = std::chrono::steady_clock::now();
+            UI::showPauseScreen();
+            int pause_ch;
+            while (isPaused) {
+                pause_ch = getch();
+                if (pause_ch == 'p' || pause_ch == 'P') {
+                    isPaused = false;
+                } else if (pause_ch == 'q' || pause_ch == 'Q') {
+                    quitPressed = true;
+                    isRunning = false;
+                    break;
+                }
+            }
+            auto pauseEndTime = std::chrono::steady_clock::now();
+            totalPausedDuration += std::chrono::duration<double>(pauseEndTime - pauseStartTime).count();
+            clear();
+            refresh();
+            continue;
+        }
+
         int ch;
         bool sawLeft = false, sawRight = false, sawSoftDrop = false;
         while ((ch = getch()) != ERR) {
@@ -271,11 +293,11 @@ void Game::handleInput(const Settings& settings, int ch) {
                         moved.setY(moved.getY() + 1);
                     }
                     GameUtils::placePiece(currentPiece, board);
-                    lastRotation = 0;
                     processLineClear();
 
                     newPiece();
 
+                    lastRotation = 0;
                     holdAvailable = true;
                     lastFallTime = std::chrono::steady_clock::now();
                     return;
@@ -285,6 +307,8 @@ void Game::handleInput(const Settings& settings, int ch) {
                     reset();
                 } else if (action == "RESTART") {
                     reset();
+                } else if (action == "PAUSE") {
+                    isPaused = !isPaused;
                 }
                 refresh();
             }
@@ -452,7 +476,7 @@ void Game::update() {
         }
     }
 
-    gameTime = std::chrono::duration<double>(now - gameStart).count();
+    gameTime = std::chrono::duration<double>(now - gameStart).count() - totalPausedDuration;
 }
 
 void Game::render() {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -24,6 +24,7 @@ std::unordered_map<std::string, std::vector<int>> Settings::keyBindings = {
     {"HOLD",    {259, 105}},         // up arrow, i key
     {"SOFT_DROP", {258, 107}},       // down arrow, k key
     {"HARD_DROP", {32}},             // space key
+    {"PAUSE",   {112}},              // p key
     {"QUIT",    {113, 27}},          // q key, esc
     {"RESTART", {114, 92}}           // r key, '\'
 };

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -134,6 +134,15 @@ void UI::renderHandling(WINDOW* win) {
     mvwprintw(win, 4, 1, "SDF: %.2f", Settings::getSDF());
 }
 
+std::string UI::formatSeconds(double seconds) {
+    int total = static_cast<int>(seconds + 0.5); // round to nearest second
+    int mins = total / 60;
+    int secs = total % 60;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d:%02d", mins, secs);
+    return std::string(buf);
+}
+
 void UI::showResultsPage(const std::string& mode, const std::unordered_map<std::string, int>& statistics, double gameTime) {
     clear();
     refresh();
@@ -178,17 +187,27 @@ void UI::showResultsPage(const std::string& mode, const std::unordered_map<std::
     std::string title, modeStat;
     if (mode.find("sprint_") != std::string::npos) {
         title = "SPRINT RESULTS";
-        char timebuf[16];
-        snprintf(timebuf, sizeof(timebuf), "%.3f s", gameTime);
-        modeStat = std::string("Time: ") + timebuf;
+        modeStat = std::string("Time: ") + formatSeconds(gameTime);
         statLines.insert(statLines.begin(), {"Score", std::to_string(statistics.at("score"))});
     } else if (mode.find("blitz_") != std::string::npos) {
         title = "BLITZ RESULTS";
         modeStat = "Score: " + std::to_string(statistics.at("score"));
-        statLines.insert(statLines.begin(), {"Time", std::to_string(gameTime) + " s"});
+        std::string gameTimeStr;
+        if (mode.find("1min") != std::string::npos) {
+            gameTimeStr = "1:00";
+        } else if (mode.find("2min") != std::string::npos) {
+            gameTimeStr = "2:00";
+        } else if (mode.find("4min") != std::string::npos) {
+            gameTimeStr = "4:00";
+        } else {
+            gameTimeStr = formatSeconds(gameTime);
+        }
+        statLines.insert(statLines.begin(), {"Time", gameTimeStr});
     } else if (mode == "zen") {
         title = "ZEN RESULTS";
         modeStat = "Lines: " + std::to_string(statistics.at("lines"));
+        statLines.insert(statLines.begin(), {"Score", std::to_string(statistics.at("score"))});
+        statLines.insert(statLines.begin(), {"Time", formatSeconds(gameTime)});
     }
 
     while (true) {

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -222,3 +222,27 @@ void UI::showResultsPage(const std::string& mode, const std::unordered_map<std::
     clear();
     refresh();
 }
+
+void UI::showPauseScreen() {
+    int term_rows, term_cols;
+    getmaxyx(stdscr, term_rows, term_cols);
+    int pause_win_height = 5;
+    int pause_win_width = 20;
+    int start_y = (term_rows - pause_win_height) / 2;
+    int start_x = (term_cols - pause_win_width) / 2;
+    WINDOW* pausewin = newwin(pause_win_height, pause_win_width, start_y, start_x);
+    box(pausewin, 0, 0);
+    wattron(pausewin, A_BOLD);
+    std::string paused = "PAUSED";
+    int paused_x = (pause_win_width - paused.size()) / 2;
+    mvwprintw(pausewin, 1, paused_x, "%s", paused.c_str());
+    wattroff(pausewin, A_BOLD);
+    std::string instr1 = "[p] to unpause";
+    std::string instr2 = "[q] to quit";
+    int instr1_x = (pause_win_width - instr1.size()) / 2;
+    int instr2_x = (pause_win_width - instr2.size()) / 2;
+    mvwprintw(pausewin, 2, instr1_x, "%s", instr1.c_str());
+    mvwprintw(pausewin, 3, instr2_x, "%s", instr2.c_str());
+    wrefresh(pausewin);
+    delwin(pausewin);
+}


### PR DESCRIPTION
This pull request introduces a pause feature to the game, improves time formatting in the UI, and refines gameplay mechanics. The most significant changes involve adding the ability to pause and resume the game, updating the game's time tracking to account for paused durations, and enhancing the display of time in the results screen.

### Pause Feature Implementation:

* [`include/Game.h`](diffhunk://#diff-ddc0e7d63d44570a0c1abdf154a5a71413c08515be3e4c94e2bb03619dda2df0R30): Added `isPaused` and `totalPausedDuration` variables to track the game's pause state and the total time spent paused. [[1]](diffhunk://#diff-ddc0e7d63d44570a0c1abdf154a5a71413c08515be3e4c94e2bb03619dda2df0R30) [[2]](diffhunk://#diff-ddc0e7d63d44570a0c1abdf154a5a71413c08515be3e4c94e2bb03619dda2df0R59)
* [`src/Game.cpp`](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819R104-R124): Implemented pause functionality in the `run` method, allowing players to pause/unpause with the 'p' key and quit from the pause screen with the 'q' key. Updated `update` to exclude paused time from `gameTime`. [[1]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819R104-R124) [[2]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L455-R479)
* [`src/Settings.cpp`](diffhunk://#diff-4694be0a587e1a04a36effbe84f9d99e36198406f7715778540aa8cbc766a521R27): Added a new key binding for the pause action ('p' key).
* [`src/UI.cpp`](diffhunk://#diff-e06b8bb76d55bd63c59e0503b931a6ef6fb5e9b02aaddbe97439539eb1f2b954R244-R267): Added `showPauseScreen` to display a pause menu with instructions.

### Time Formatting Enhancements:

* [`include/UI.h`](diffhunk://#diff-73a2318fd849899791ba1e0f8ae99933147f287daf7895534baf0258e31246e0R17-R19): Added the `formatSeconds` method for consistent and readable time formatting.
* [`src/UI.cpp`](diffhunk://#diff-e06b8bb76d55bd63c59e0503b931a6ef6fb5e9b02aaddbe97439539eb1f2b954L181-R210): Updated `showResultsPage` to use `formatSeconds` for displaying game time in a user-friendly format.

### Gameplay Refinements:

* [`src/Game.cpp`](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L257-R279): Adjusted the initial Y position of held pieces and ensured `lastRotation` is reset after placing a piece. [[1]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L257-R279) [[2]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L274-R300)