### PR TITLE
v0.4.1: New versioning system with branch protection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Auto Release and Homebrew Update
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
   workflow_dispatch:
@@ -22,59 +23,59 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Repository checkout
+        uses: actions/checkout@v4
 
-      - name: Get latest tag
+      - name: Get tag from PR title or latest tag
         id: get_tag
         run: |
-          git fetch --tags
-          latest=$(git tag --sort=-v:refname | head -n1)
-          if [[ -z "$latest" ]]; then
-            latest="v0.0.0"
+          TITLE="${{ github.event.pull_request.title }}"
+          if [[ "$TITLE" =~ (v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            echo "new_tag=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          else 
+            git fetch --tags
+            latest=$(git tag --sort=-v:refname | head -n1)
+            if [[ -z "$latest" ]]; then
+              latest="v0.0.0"
+            fi
+            IFS='.' read -r -a parts <<< "${latest#v}"
+            if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event.inputs.release-type }}" == "patch" ]]; then
+              major="${parts[0]}"
+              minor="${parts[1]}"
+              patch="${parts[2]}"
+              patch=$((patch + 1))
+            elif [[ "${{ github.event.inputs.release-type }}" == "minor" ]]; then
+              major="${parts[0]}"
+              minor="${parts[1]}"
+              minor=$((minor + 1))
+              patch=0
+            elif [[ "${{ github.event.inputs.release-type }}" == "major" ]]; then
+              major=$((parts[0] + 1))
+              minor=0
+              patch=0
+            fi
+            new_tag="v$major.$minor.$patch"
+            echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
           fi
-          echo "latest_tag=$latest" >> $GITHUB_OUTPUT
-
-      - name: Bump version
-        id: bump
-        run: |
-          latest="${{ steps.get_tag.outputs.latest_tag }}"
-          IFS='.' read -r -a parts <<< "${latest#v}"
-          if [[ "${{ github.event_name }}" == "push" || "${{ github.event.inputs.release-type }}" == "patch" ]]; then
-            major="${parts[0]}"
-            minor="${parts[1]}"
-            patch="${parts[2]}"
-            patch=$((patch + 1))
-          elif [[ "${{ github.event.inputs.release-type }}" == "minor" ]]; then
-            major="${parts[0]}"
-            minor="${parts[1]}"
-            minor=$((minor + 1))
-            patch=0
-          elif [[ "${{ github.event.inputs.release-type }}" == "major" ]]; then
-            major=$((parts[0] + 1))
-            minor=0
-            patch=0
-          fi
-          new_tag="v$major.$minor.$patch"
-          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
 
       - name: Create and push tag
         run: |
           git config user.name "FinityFly"
           git config user.email "daniel1211.lu@gmail.com"
-          git tag ${{ steps.bump.outputs.new_tag }}
-          git push origin ${{ steps.bump.outputs.new_tag }}
+          git tag ${{ steps.get_tag.outputs.new_tag }}
+          git push origin ${{ steps.get_tag.outputs.new_tag }}
 
       - name: Create tarball
         run: |
-          mkdir clitris-${{ steps.bump.outputs.new_tag }}
-          rsync -av --exclude "clitris-${{ steps.bump.outputs.new_tag }}" ./ clitris-${{ steps.bump.outputs.new_tag }}/
-          tar -czf clitris-${{ steps.bump.outputs.new_tag }}.tar.gz clitris-${{ steps.bump.outputs.new_tag }}
+          mkdir clitris-${{ steps.get_tag.outputs.new_tag }}
+          rsync -av --exclude "clitris-${{ steps.get_tag.outputs.new_tag }}" ./ clitris-${{ steps.get_tag.outputs.new_tag }}/
+          tar -czf clitris-${{ steps.get_tag.outputs.new_tag }}.tar.gz clitris-${{ steps.get_tag.outputs.new_tag }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.bump.outputs.new_tag }}
-          files: clitris-${{ steps.bump.outputs.new_tag }}.tar.gz
+          tag_name: ${{ steps.get_tag.outputs.new_tag }}
+          files: clitris-${{ steps.get_tag.outputs.new_tag }}.tar.gz
 
       - name: Dispatch update to tap
         uses: peter-evans/repository-dispatch@v3
@@ -84,6 +85,6 @@ jobs:
           event-type: clitris_release
           client-payload: |
             {
-              "tarball_url": "https://github.com/FinityFly/clitris/releases/download/${{ steps.bump.outputs.new_tag }}/clitris-${{ steps.bump.outputs.new_tag }}.tar.gz",
-              "version": "${{ steps.bump.outputs.new_tag }}"
+              "tarball_url": "https://github.com/FinityFly/clitris/releases/download/${{ steps.get_tag.outputs.new_tag }}/clitris-${{ steps.get_tag.outputs.new_tag }}.tar.gz",
+              "version": "${{ steps.get_tag.outputs.new_tag }}"
             }


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases to improve its functionality and adapt it for use with pull requests. The key changes include switching the trigger from `push` to `pull_request` events, enhancing tag handling, and simplifying version bump logic.

### Workflow Trigger Changes:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL4-R5): Changed the workflow trigger to respond to `pull_request` events of type `closed` instead of `push` events. This ensures the workflow runs when a pull request is merged.

### Tag and Version Handling Updates:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL25-R42): Enhanced the logic to extract the version tag from the pull request title if available, falling back to the latest Git tag otherwise. This simplifies version management during releases.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR59-R78): Updated all references to use `steps.get_tag.outputs.new_tag` instead of `steps.bump.outputs.new_tag` for consistency and clarity in tag handling.

### Release Asset and Dispatch Adjustments:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR59-R78): Modified the tarball creation and GitHub release steps to use the new tag output, ensuring accurate versioning in release assets.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL87-R89): Adjusted the repository dispatch payload to reference the updated tag output for the tarball URL and version.